### PR TITLE
bump evaluate to 0.3.0

### DIFF
--- a/whisper_finetune/requirements.txt
+++ b/whisper_finetune/requirements.txt
@@ -1,4 +1,4 @@
-evaluate==0.2.2
+evaluate==0.3.0
 flake8==5.0.4
 isort==5.10.1
 jiwer==2.5.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.